### PR TITLE
Forgot to update cyaraos-release files in git

### DIFF
--- a/cyaraos-release/cyaraos-release-el9.spec
+++ b/cyaraos-release/cyaraos-release-el9.spec
@@ -7,14 +7,16 @@
 # Gortnaclohy
 # Tooreennasillane
 # Lahernathee
-%global release_name Mallavonea
+# Mallavonea
+%global release_name Abbeystrewry
 %global major   9
-%global minor   3
+%global minor   4
 %global dist .el%{major}
+%global eol_date 2032-06-01
 
 Name:           cyaraos-release
 Version:        %{major}.%{minor}
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        %{distro} release files
 License:        GPLv2
 BuildArch:      noarch
@@ -77,6 +79,7 @@ Summary: %{distro} public secureboot certificates
 Group: System Environment/Base
 Provides: system-sb-certs = %{version}-%{release}
 Provides: redhat-sb-certs = %{version}-%{release}
+Provides: centos-sb-certs = %{version}-%{release}
 
 %package -n almalinux-repos
 Summary:        %{distro} package repositories
@@ -314,10 +317,13 @@ install -p -m 0644 %{SOURCE600} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/
 
 
 %changelog
+* Mon May 13 2024 Patrick Coakley <patrick.coakley@cyara.com> - 9.4-3
+- CyaraOS 9.4
+
 * Fri Nov 24 2023 Patrick Coakley <patrick.coakley@cyara.com> - 9.3-1
 - CyaraOS 9.3
 
-* Mon June 12 2023 Patrick Coakley <patrick.coakley@cyara.com> - 9.2-2
+* Mon Jun 12 2023 Patrick Coakley <patrick.coakley@cyara.com> - 9.2-2
 - CyaraOS 9.2
 
 * Tue May 02 2023 Andrew Lukoshko <alukoshko@almalinux.org> - 9.2-1

--- a/cyaraos-release/cyaraos-release.spec
+++ b/cyaraos-release/cyaraos-release.spec
@@ -10,17 +10,18 @@
 # Carrigfadda
 # Gortnaclohy
 # Tooreennasillane
-%define release_name Derreendangan
-
+#Derreendangan
+%define release_name Coolnagarrane
 %define contentdir almalinux
 %define infra_var stock
 %define base_release_version 8
-%define full_release_version 8.9
+%define full_release_version 8.10
 %define dist_release_version 8
-%define upstream_rel_long 8.9-0.1
-%define upstream_rel 8.9
+%define upstream_rel_long 8.10-0.2
+%define upstream_rel 8.10
 %define cyaraos_rel 1
 %define dist .el%{dist_release_version}
+%global eol_date 2029-06-01
 
 # The anaconda scripts in %%{_libexecdir} can create false requirements
 %global __requires_exclude_from %{_libexecdir}
@@ -215,9 +216,11 @@ rm -rf %{buildroot}
 %{_prefix}/lib/systemd/system-preset/*
 
 %changelog
+* Thu May 30 2024 Patrick Coakley <patrick.coakley@cyara.com> - 8.10-1
+- Update to 8.10
+
 * Fri Nov 24 2023 Patrick Coakley <patrick.coakley@cyara.com> - 8.9-1
 - Update to 8.9
-
 
 * Thu May 18 2023 Patrick Coakley <patrick.coakley@cyara.com> - 8.8-1
 - Update to 8.8


### PR DESCRIPTION
These builds are still carried out manually on osbuilder

Forgot to update here in git after 9.4 and 8.10 were released 